### PR TITLE
Resolve dependency graph for modules and bootstrap. 

### DIFF
--- a/src/client/app/app.module.js
+++ b/src/client/app/app.module.js
@@ -4,6 +4,8 @@
     angular
         .module("app", [
             "app.core",
+            "app.filters",
+            "app.newrelic",
             "app.widgets"
         ]);
 

--- a/src/client/app/core/core.module.js
+++ b/src/client/app/core/core.module.js
@@ -3,8 +3,6 @@
 
     angular
         .module("app.core", [
-            "emguo.poller",
-            "LocalStorageModule",
-            "app.newrelic"
+            "LocalStorageModule"
         ]);
 }());

--- a/src/client/app/newrelic/newrelic.module.js
+++ b/src/client/app/newrelic/newrelic.module.js
@@ -3,8 +3,8 @@
 
     angular
         .module("app.newrelic", [
+            "emguo.poller",
             "ngResource",
-            "LocalStorageModule",
-            "app.filters"
+            "LocalStorageModule"
         ]);
 }());

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -13,6 +13,13 @@
     <link rel="stylesheet" type="text/css" href="content/css/style.css">
 
     <title>{{user.name}} Boxes</title>
+    <style>
+        /* This helps the ng-show/ng-hide animations start at the right place. */
+        /* Since Angular has this but needs to load, this gives us the class early. */
+        .ng-hide {
+            display: none!important;
+        }
+    </style>
     <meta name="description" content="New Relic server / application boxes dashboard">
     <link id="favicon" rel="shortcut icon" type="image/png" href="{{user.favicon}}"/>
 </head>


### PR DESCRIPTION
Add in early .ng-hide class to ease animations in before pageload.

Modules were messy and defined in a bad graph. New dep. bootstrap reads:

app.module.js
- app.core
- app.filters
- app.newrelic
- app.widgets

Keeps all widgets isolated from each other, except for third party dependencies.

Note: Karma and ng-mock can now identify these modules independently.
