### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#New Relic Boxes
+# New Relic Boxes
 
 [![Code Climate](https://codeclimate.com/github/buzzedword/new-relic-boxes/badges/gpa.svg)](https://codeclimate.com/github/buzzedword/new-relic-boxes) [![Build Status](https://travis-ci.org/buzzedword/new-relic-boxes.svg?branch=master)](https://travis-ci.org/buzzedword/new-relic-boxes)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
